### PR TITLE
Make `isResetOption` independent from static value "relevance"

### DIFF
--- a/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
+++ b/Classes/Domain/Search/ResultSet/ResultSetReconstitutionProcessor.php
@@ -124,7 +124,12 @@ class ResultSetReconstitutionProcessor implements SearchResultSetProcessor
             $field = $sortingOptions['field'];
             $label = $sortingOptions['label'];
 
-            $isResetOption = $field === 'relevance';
+            $sortBy = explode(' ', $configuration->getSearchQuerySortBy())[0];
+            if ($sortBy === '') {
+                $sortBy = 'relevance';
+            }
+
+            $isResetOption = $field === $sortBy;
 
             // Allow stdWrap on label:
             $labelHasSubConfiguration = is_array($sortingOptions['label.']);

--- a/Classes/System/Configuration/TypoScriptConfiguration.php
+++ b/Classes/System/Configuration/TypoScriptConfiguration.php
@@ -1437,6 +1437,19 @@ class TypoScriptConfiguration
     }
 
     /**
+     * Return the configured query sortBy value.
+     *
+     * plugin.tx_solr.search.query.sortBy
+     *
+     * @param string $defaultIfEmpty
+     * @return string
+     */
+     public function getSearchQuerySortBy($defaultIfEmpty = ''){
+
+        return $this->getValueByPathOrDefaultValue('plugin.tx_solr.search.query.sortBy', $defaultIfEmpty);
+    }
+
+    /**
      * Returns the configured target page for the search.
      * By default the contextPageId will be used
      *


### PR DESCRIPTION
# What this pr does
Improve the bugfix.

Unfortunately it introduces another problem (see below).

# How to test
1. Set `plugin.tx_solr.search.query.sortBy` to something different than "relevance".
2. See that the facet you choose in step 1 is active
3. Test whether you can sort by "relevance".
4.  Test that it's also working if `plugin.tx_solr.search.query.sortBy` is not set ("relevance" is active now), other facets can be activateed as well.

# New problem:
It's not possible to change the sort direction of the value that is set in `plugin.tx_solr.search.query.sortBy`.

Improves: #2541
